### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/org.easycoding.TunedSwitcher.yml
+++ b/org.easycoding.TunedSwitcher.yml
@@ -11,7 +11,6 @@ finish-args:
   - --system-talk-name=org.freedesktop.systemd1
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.*
 command: tuned-switcher
 modules:
   - name: tuned-switcher


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025


I assume this was for tray, if it was for anything else, it needs to be figured out.